### PR TITLE
Add Steal Games menu and UI tweaks

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -62,9 +62,11 @@ codex_rules_and_structure.txt – this file
 │   └── `loader.lua`
 │       ↳ Loads MainUI and AddMenuButton.
 │       ↳ Initializes main GUI logic:
+│          • Waits 5s before loading UI
 │          • Menu button toggle
-│          • Adds “Research Menu” and “General”
+│          • Adds “Research Menu”, “General”, and “Steal Games”
 │          • Toggles between List and Grid views
-│          • Sets player name & avatar
+│          • Sets player name & avatar from UserId
 │          • Handles close (X) logic
 │          • Adds sample toggle buttons to Research Menu
+│          • Adds TP Stealer button under Steal Games

--- a/Scripts/UiLib/MainUI.lua
+++ b/Scripts/UiLib/MainUI.lua
@@ -28,6 +28,12 @@ local TextButton_2 = Instance.new("TextButton")
 local UIPadding_3 = Instance.new("UIPadding")
 local UIGridLayout = Instance.new("UIGridLayout")
 local MenuButton = Instance.new("TextButton")
+local function addStroke(obj)
+    local s = Instance.new("UIStroke")
+    s.Color = Color3.new(0,0,0)
+    s.Thickness = 1
+    s.Parent = obj
+end
 
 --Properties:
 
@@ -69,6 +75,7 @@ TextButton.TextColor3 = Color3.fromRGB(255, 255, 255)
 TextButton.TextScaled = true
 TextButton.TextSize = 14.000
 TextButton.TextWrapped = true
+addStroke(TextButton)
 
 UIListLayout.Parent = ListScrolling
 UIListLayout.SortOrder = Enum.SortOrder.LayoutOrder
@@ -90,6 +97,7 @@ TextLabel.TextColor3 = Color3.fromRGB(255, 255, 255)
 TextLabel.TextScaled = true
 TextLabel.TextSize = 14.000
 TextLabel.TextWrapped = true
+addStroke(TextLabel)
 
 Side.Name = "Side"
 Side.Parent = Background
@@ -112,6 +120,7 @@ Menus.Font = Enum.Font.SourceSans
 Menus.TextColor3 = Color3.fromRGB(255, 255, 255)
 Menus.TextSize = 48.000
 Menus.TextWrapped = true
+addStroke(Menus)
 
 UIListLayout_2.Parent = Side
 UIListLayout_2.SortOrder = Enum.SortOrder.LayoutOrder
@@ -153,6 +162,7 @@ PlayerName.TextColor3 = Color3.fromRGB(255, 255, 255)
 PlayerName.TextScaled = true
 PlayerName.TextSize = 14.000
 PlayerName.TextWrapped = true
+addStroke(PlayerName)
 
 Version.Name = "Version"
 Version.Parent = Personal
@@ -169,6 +179,7 @@ Version.TextColor3 = Color3.fromRGB(255, 255, 255)
 Version.TextScaled = true
 Version.TextSize = 14.000
 Version.TextWrapped = true
+addStroke(Version)
 
 X.Name = "X"
 X.Parent = Background
@@ -184,6 +195,7 @@ X.TextColor3 = Color3.fromRGB(255, 0, 0)
 X.TextScaled = true
 X.TextSize = 14.000
 X.TextWrapped = true
+addStroke(X)
 
 Name.Name = "Name"
 Name.Parent = Background
@@ -200,6 +212,7 @@ Name.TextColor3 = Color3.fromRGB(255, 255, 255)
 Name.TextScaled = true
 Name.TextSize = 14.000
 Name.TextWrapped = true
+addStroke(Name)
 
 GridScrolling.Name = "GridScrolling"
 GridScrolling.Parent = Background
@@ -222,6 +235,7 @@ TextButton_2.TextColor3 = Color3.fromRGB(255, 255, 255)
 TextButton_2.TextScaled = true
 TextButton_2.TextSize = 14.000
 TextButton_2.TextWrapped = true
+addStroke(TextButton_2)
 
 UIPadding_3.Parent = GridScrolling
 UIPadding_3.PaddingLeft = UDim.new(0, 5)
@@ -245,6 +259,7 @@ MenuButton.TextColor3 = Color3.fromRGB(255, 255, 255)
 MenuButton.TextScaled = true
 MenuButton.TextSize = 14.000
 MenuButton.TextWrapped = true
+addStroke(MenuButton)
 
 return {
         ScreenGui = ScreenGui,

--- a/Scripts/UiLib/loader.lua
+++ b/Scripts/UiLib/loader.lua
@@ -1,7 +1,11 @@
+local Players = game:GetService("Players")
+
+-- wait for assets to load
+task.wait(5)
+
 local MainUI = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/MainUI.lua"))()
 local AddMenuButton = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/AddMenuButton.lua"))()
 local AddToggleGridButton = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/AddToggleGridButton.lua"))()
-local Players = game:GetService("Players")
 
 -- Make GUI draggable
 MainUI.Background.Active = true
@@ -26,6 +30,26 @@ AddMenuButton(MainUI.Side, MainUI.MenusTemplate, "General", function()
         MainUI.GridScrolling.Visible = false
 end)
 
+-- Add "Steal Games" button to Side
+AddMenuButton(MainUI.Side, MainUI.MenusTemplate, "Steal Games", function()
+        AddToggleGridButton.Reset()
+        for _, child in ipairs(MainUI.GridScrolling:GetChildren()) do
+                if child ~= MainUI.GridTemplate and child:IsA("GuiObject") then
+                        child:Destroy()
+                end
+        end
+        MainUI.GridScrolling.Visible = true
+        MainUI.ListScrolling.Visible = false
+        AddToggleGridButton.AddButton(
+                MainUI.GridScrolling,
+                MainUI.GridTemplate,
+                "TP Stealer",
+                function()
+                        return loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/Steal%20a%20Baddie%20Project/combined_auto_tp_stealer.lua"))()
+                end
+        )
+end)
+
 -- Set PlayerName and Version labels
 local player = Players.LocalPlayer
 MainUI.PlayerName.Text = player.Name
@@ -41,21 +65,11 @@ AddToggleGridButton.AddButton(
         end
 )
 
--- Show local player's character in ViewportFrame
+-- Show local player's avatar in ViewportFrame using their UserId
 task.spawn(function()
-	local character = player.Character or player.CharacterAdded:Wait()
-	local clone = character:Clone()
-
-	-- Remove scripts from clone
-	for _, obj in clone:GetDescendants() do
-		if obj:IsA("Script") or obj:IsA("LocalScript") then
-			obj:Destroy()
-		end
-	end
-
-	-- Clean and show clone in viewport
-	MainUI.Player:ClearAllChildren()
-	clone.Parent = MainUI.Player
+        local avatar = Players:CreateHumanoidModelFromUserId(player.UserId)
+        MainUI.Player:ClearAllChildren()
+        avatar.Parent = MainUI.Player
 
 	local camera = Instance.new("Camera")
 	camera.CFrame = CFrame.new(Vector3.new(0, 2, 8), Vector3.new(0, 2, 0))


### PR DESCRIPTION
## Summary
- support text stroke for all UI buttons by cloning templates with `UIStroke`
- delay UI load by 5 seconds in `loader.lua`
- show player's avatar in the viewport via `CreateHumanoidModelFromUserId`
- add new **Steal Games** menu that loads TP Stealer script
- update docs about new loader behavior

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862d82f5b6c8322a395301f87496d06