### PR TITLE
Implement independent sidebar layouts with ESP toggle

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -24,9 +24,11 @@ important_notes_for_codex.txt – usage context and rules
 codex_rules_and_structure.txt – this file
 
 📁 Scripts  
-├── 📁 General Tools  
-│   └── *(Empty)*  
-│   ↳ Will contain common utility features like ESP, fly, speed, noclip, etc.
+├── 📁 General Tools
+│   └── `SimpleESP.lua`
+│       ↳ Provides basic Highlight-based ESP for other players.
+│       ↳ Exposes Enable/Disable functions used by UI toggle buttons.
+│   ↳ Folder may contain other utilities like fly, speed, noclip, etc.
 
 ├── 📁 Research Tools
 │   └── `Character Info Watcher.lua`
@@ -56,17 +58,12 @@ codex_rules_and_structure.txt – this file
 │   │   ↳ Handles template cloning, text assignment, callback binding.
 │   │   ↳ Used by loader.lua to insert dynamic pages like “Research Menu”.
 │   ├── `AddToggleGridButton.lua`
-│   │   ↳ Adds toggleable buttons to GridScrolling and tracks state.
-│   │   ↳ Provides Reset() to disable active modules.
+│   │   ↳ Returns CreateController() to build isolated toggle controllers.
+│   │   ↳ Each controller manages its own buttons and Reset logic.
 
 │   └── `loader.lua`
-│       ↳ Loads MainUI and AddMenuButton.
-│       ↳ Initializes main GUI logic:
-│          • Waits 5s before loading UI
-│          • Menu button toggle
-│          • Adds “Research Menu”, “General”, and “Steal Games”
-│          • Toggles between List and Grid views
-│          • Sets player name & avatar from UserId
-│          • Handles close (X) logic
-│          • Adds sample toggle buttons to Research Menu
-│          • Adds TP Stealer button under Steal Games
+│       ↳ Loads MainUI and menu utilities.
+│       ↳ Creates independent Grid layouts for Research, General, and Steal Games.
+│       ↳ Each sidebar button opens its own cloned layout and closes the others.
+│       ↳ Adds Character Info, Toggle ESP, and Steal a Baddie buttons to respective pages.
+│       ↳ Handles avatar display, menu toggle, and close (X) behavior.

--- a/Scripts/General Tools/SimpleESP.lua
+++ b/Scripts/General Tools/SimpleESP.lua
@@ -1,0 +1,41 @@
+local module = {}
+local Players = game:GetService("Players")
+local connections = {}
+local highlights = {}
+local enabled = false
+
+local function addHighlight(char)
+    local highlight = Instance.new("Highlight")
+    highlight.Adornee = char
+    highlight.FillColor = Color3.fromRGB(255,0,0)
+    highlight.OutlineColor = Color3.fromRGB(255,255,255)
+    highlight.Parent = char
+    table.insert(highlights, highlight)
+end
+
+function module.Enable()
+    if enabled then return end
+    enabled = true
+    for _, plr in ipairs(Players:GetPlayers()) do
+        if plr ~= Players.LocalPlayer then
+            local char = plr.Character or plr.CharacterAdded:Wait()
+            addHighlight(char)
+            connections[#connections+1] = plr.CharacterAdded:Connect(addHighlight)
+        end
+    end
+end
+
+function module.Disable()
+    if not enabled then return end
+    enabled = false
+    for _, conn in ipairs(connections) do
+        conn:Disconnect()
+    end
+    connections = {}
+    for _, h in ipairs(highlights) do
+        h:Destroy()
+    end
+    highlights = {}
+end
+
+return module

--- a/Scripts/UiLib/AddToggleGridButton.lua
+++ b/Scripts/UiLib/AddToggleGridButton.lua
@@ -1,11 +1,13 @@
-local activeButtons = {}
 
-local function cleanupEntry(entry)
-    if entry.enabled then
-        local obj = entry.handle
-        if obj then
-            if typeof(obj) == "Instance" and obj.Destroy then
-                obj:Destroy()
+local function createController()
+    local activeButtons = {}
+
+    local function cleanupEntry(entry)
+        if entry.enabled then
+            local obj = entry.handle
+            if obj then
+                if typeof(obj) == "Instance" and obj.Destroy then
+                    obj:Destroy()
             elseif type(obj) == "table" then
                 if obj.Disable then
                     obj:Disable()
@@ -20,21 +22,22 @@ local function cleanupEntry(entry)
             end
         end
     end
-    entry.enabled = false
-    entry.handle = nil
-end
+        end
+        entry.enabled = false
+        entry.handle = nil
+    end
 
-local ToggleLib = {}
+    local ToggleLib = {}
 
-function ToggleLib.AddButton(gridFrame, templateButton, labelText, moduleLoader)
-    local btn = templateButton:Clone()
-    btn.Name = labelText:gsub("%s+", "")
-    btn.Text = labelText
-    btn.Visible = true
-    btn.Parent = gridFrame
+    function ToggleLib.AddButton(gridFrame, templateButton, labelText, moduleLoader)
+        local btn = templateButton:Clone()
+        btn.Name = labelText:gsub("%s+", "")
+        btn.Text = labelText
+        btn.Visible = true
+        btn.Parent = gridFrame
 
     local entry = {enabled=false, handle=nil, loader=moduleLoader}
-    activeButtons[btn] = entry
+        activeButtons[btn] = entry
 
     local function enable()
         local result
@@ -59,23 +62,26 @@ function ToggleLib.AddButton(gridFrame, templateButton, labelText, moduleLoader)
         cleanupEntry(entry)
     end
 
-    btn.MouseButton1Click:Connect(function()
-        entry.enabled = not entry.enabled
-        if entry.enabled then
-            enable()
-        else
-            disable()
-        end
-    end)
+        btn.MouseButton1Click:Connect(function()
+            entry.enabled = not entry.enabled
+            if entry.enabled then
+                enable()
+            else
+                disable()
+            end
+        end)
 
-    return btn
-end
-
-function ToggleLib.Reset()
-    for _, entry in pairs(activeButtons) do
-        cleanupEntry(entry)
+        return btn
     end
-    activeButtons = {}
+
+    function ToggleLib.Reset()
+        for _, entry in pairs(activeButtons) do
+            cleanupEntry(entry)
+        end
+        activeButtons = {}
+    end
+
+    return ToggleLib
 end
 
-return ToggleLib
+return {CreateController = createController}

--- a/Scripts/UiLib/loader.lua
+++ b/Scripts/UiLib/loader.lua
@@ -5,7 +5,43 @@ task.wait(5)
 
 local MainUI = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/MainUI.lua"))()
 local AddMenuButton = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/AddMenuButton.lua"))()
-local AddToggleGridButton = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/AddToggleGridButton.lua"))()
+local ToggleGridFactory = loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/UiLib/AddToggleGridButton.lua"))()
+
+-- utility to create an isolated grid layout with its own toggle controller
+local function createGridPage()
+    local frame = MainUI.GridScrolling:Clone()
+    frame.Visible = false
+    frame.Parent = MainUI.Background
+    local template = frame:FindFirstChild(MainUI.GridTemplate.Name)
+    local controller = ToggleGridFactory.CreateController()
+    return {
+        frame = frame,
+        template = template,
+        controller = controller
+    }
+end
+
+-- pages table holds all sidebar page data
+local pages = {
+    Research = createGridPage(),
+    General = createGridPage(),
+    StealGames = createGridPage()
+}
+
+local function hideAll()
+    for _, info in pairs(pages) do
+        info.controller.Reset()
+        info.frame.Visible = false
+    end
+end
+
+local function showPage(name)
+    hideAll()
+    local page = pages[name]
+    if page then
+        page.frame.Visible = true
+    end
+end
 
 -- Make GUI draggable
 MainUI.Background.Active = true
@@ -16,38 +52,15 @@ MainUI.MenuButton.MouseButton1Click:Connect(function()
 	MainUI.Background.Visible = not MainUI.Background.Visible
 end)
 
--- Add "Research Menu" button to Side
-AddMenuButton(MainUI.Side, MainUI.MenusTemplate, "Research Menu", function()
-        AddToggleGridButton.Reset()
-        MainUI.GridScrolling.Visible = true
-        MainUI.ListScrolling.Visible = false
+-- Add sidebar buttons
+AddMenuButton(MainUI.Side, MainUI.MenusTemplate, "Research", function()
+    showPage("Research")
 end)
-
--- Add "General" button to Side
 AddMenuButton(MainUI.Side, MainUI.MenusTemplate, "General", function()
-        AddToggleGridButton.Reset()
-        MainUI.ListScrolling.Visible = true
-        MainUI.GridScrolling.Visible = false
+    showPage("General")
 end)
-
--- Add "Steal Games" button to Side
 AddMenuButton(MainUI.Side, MainUI.MenusTemplate, "Steal Games", function()
-        AddToggleGridButton.Reset()
-        for _, child in ipairs(MainUI.GridScrolling:GetChildren()) do
-                if child ~= MainUI.GridTemplate and child:IsA("GuiObject") then
-                        child:Destroy()
-                end
-        end
-        MainUI.GridScrolling.Visible = true
-        MainUI.ListScrolling.Visible = false
-        AddToggleGridButton.AddButton(
-                MainUI.GridScrolling,
-                MainUI.GridTemplate,
-                "TP Stealer",
-                function()
-                        return loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/Steal%20a%20Baddie%20Project/combined_auto_tp_stealer.lua"))()
-                end
-        )
+    showPage("StealGames")
 end)
 
 -- Set PlayerName and Version labels
@@ -56,13 +69,31 @@ MainUI.PlayerName.Text = player.Name
 MainUI.Version.Text = "Developer"
 
 -- Example button in Research Menu
-AddToggleGridButton.AddButton(
-        MainUI.GridScrolling,
-        MainUI.GridTemplate,
-        "Character Info",
-        function()
-                return loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/Research%20Tools/Character%20Info%20Watcher.lua"))()
-        end
+pages.Research.controller.AddButton(
+    pages.Research.frame,
+    pages.Research.template,
+    "Character Info",
+    function()
+        return loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/Research%20Tools/Character%20Info%20Watcher.lua"))()
+    end
+)
+
+pages.General.controller.AddButton(
+    pages.General.frame,
+    pages.General.template,
+    "Toggle ESP",
+    function()
+        return loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/General%20Tools/SimpleESP.lua"))()
+    end
+)
+
+pages.StealGames.controller.AddButton(
+    pages.StealGames.frame,
+    pages.StealGames.template,
+    "Steal a Baddie",
+    function()
+        return loadstring(game:HttpGet("https://raw.githubusercontent.com/ColinPogu/epic-roblox-scripts/main/Scripts/Steal%20a%20Baddie%20Project/combined_auto_tp_stealer.lua"))()
+    end
 )
 
 -- Show local player's avatar in ViewportFrame using their UserId
@@ -79,6 +110,6 @@ end)
 
 -- X button hides UI but not MenuButton
 MainUI.X.MouseButton1Click:Connect(function()
-        AddToggleGridButton.Reset()
+        hideAll()
         MainUI.Background.Visible = false
 end)


### PR DESCRIPTION
## Summary
- refactor `AddToggleGridButton.lua` to return `CreateController` for isolated toggle logic
- add `SimpleESP.lua` utility module
- update `loader.lua` to clone unique layouts for Research, General, and Steal Games
- add ESP and Steal a Baddie buttons to respective pages
- document new structure in `codex_rules_and_structure.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862ea8b1d948322a5ece5a415201751