### PR TITLE
Use GridScrolling for page buttons

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -61,8 +61,8 @@ codex_rules_and_structure.txt – this file
 │   │   ↳ Returns CreateController() to build isolated toggle controllers.
 │   │   ↳ Each controller manages its own buttons and Reset logic.
 │   ├── `pages.lua`
-│   │   ↳ Creates and manages page containers within the UI.
-│   │   ↳ Provides showPage and createPage utilities.
+│   │   ↳ Dynamically clones page buttons into MainUI's GridScrolling frame.
+│   │   ↳ showPage toggles which set of buttons is visible.
 │   ├── `sidebar.lua`
 │   │   ↳ Builds the sidebar menu using AddMenuButton.
 │   │   ↳ Connects sidebar buttons to pages.lua page switching.

--- a/Scripts/UiLib/loader.lua
+++ b/Scripts/UiLib/loader.lua
@@ -22,8 +22,8 @@ return function()
     -- Utility for cloning sidebar buttons
     local addMenuButton = loadRemote("Scripts/UiLib/AddMenuButton.lua")
 
-    -- Set up pages container and default pages
-    local pagesModule = loadRemote("Scripts/UiLib/pages.lua", ui.Background, ui.GridTemplate)
+    -- Set up pages container and default pages using the GridScrolling frame
+    local pagesModule = loadRemote("Scripts/UiLib/pages.lua", ui.GridScrolling, ui.GridTemplate)
     print("[loader] pages module loaded")
 
     -- Build the sidebar and connect buttons to page switching

--- a/Scripts/UiLib/pages.lua
+++ b/Scripts/UiLib/pages.lua
@@ -1,50 +1,41 @@
 print("[pages.lua] executing")
 
-return function(parent, templateButton)
+return function(gridFrame, templateButton)
     print("[pages.lua] setting up pages")
-    local container = Instance.new("Frame")
-    container.Name = "Pages"
-    container.Size = UDim2.new(1, 0, 1, 0)
-    container.BackgroundTransparency = 1
-    container.Parent = parent
+
+    gridFrame.Visible = true
 
     local pages = {}
 
     local function createPage(name)
-        local page = Instance.new("Frame")
-        page.Name = name
-        page.Size = UDim2.new(1, 0, 1, 0)
-        page.BackgroundTransparency = 1
-        page.Visible = false
-        page.Parent = container
-
-        local layout = Instance.new("UIGridLayout")
-        layout.CellSize = templateButton.Size
-        layout.CellPadding = UDim2.new(0, 5, 0, 5)
-        layout.Parent = page
-
+        local buttons = {}
         for i = 1, 3 do
             local btn = templateButton:Clone()
             btn.Text = name .. " Btn " .. i
-            btn.Visible = true
-            btn.Parent = page
+            btn.Visible = false
+            btn.Parent = gridFrame
+            table.insert(buttons, btn)
         end
 
-        pages[name] = page
-        return page
+        pages[name] = buttons
+        return buttons
     end
 
     local function hideAll()
-        for _, p in pairs(pages) do
-            p.Visible = false
+        for _, btns in pairs(pages) do
+            for _, b in ipairs(btns) do
+                b.Visible = false
+            end
         end
     end
 
     local function showPage(name)
         hideAll()
-        local page = pages[name]
-        if page then
-            page.Visible = true
+        local btns = pages[name]
+        if btns then
+            for _, b in ipairs(btns) do
+                b.Visible = true
+            end
             print("[pages.lua] showing page", name)
         else
             warn("[pages.lua] no page named " .. tostring(name))
@@ -58,7 +49,6 @@ return function(parent, templateButton)
 
     print("[pages.lua] ready")
     return {
-        container = container,
         pages = pages,
         createPage = createPage,
         showPage = showPage


### PR DESCRIPTION
## Summary
- refactor `pages.lua` so pages clone their buttons directly into the existing `GridScrolling` frame from `MainUI.lua`
- update loader to pass `GridScrolling` into `pages.lua`
- document the new `pages.lua` behavior in `codex_rules_and_structure.txt`

## Testing
- `luac -p Scripts/UiLib/pages.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f77ea5e08322b4f53aa9a4a307a0