### PR TITLE
Add default buttons loader

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -68,6 +68,9 @@ codex_rules_and_structure.txt – this file
 │   ├── `sidebar.lua`
 │   │   ↳ Builds the sidebar menu using AddMenuButton.
 │   │   ↳ Connects sidebar buttons to pages.lua page switching.
+│   ├── `default_buttons.lua`
+│   │   ↳ Populates pages with toggleable grid buttons like "Steal a Baddie".
+│   │   ↳ Uses AddToggleGridButton to load modules on demand.
 │   └── `loader.lua`
 │       ↳ Master loader hub for the UI library.
 │       ↳ Dynamically fetches and executes MainUI.lua, pages.lua, and sidebar.lua.

--- a/Scripts/UiLib/default_buttons.lua
+++ b/Scripts/UiLib/default_buttons.lua
@@ -1,0 +1,24 @@
+return function(pagesModule, toggleLib, loadRemote)
+    print("[default_buttons] adding default page buttons")
+    local controllers = {}
+
+    local function add(pageName, label, path)
+        local page = pagesModule.pages[pageName]
+        if not page then
+            warn("[default_buttons] missing page: " .. pageName)
+            return
+        end
+        local ctrl = controllers[pageName]
+        if not ctrl then
+            ctrl = toggleLib.CreateController()
+            controllers[pageName] = ctrl
+        end
+        ctrl.AddButton(page.Frame, page.Template, label, function()
+            return loadRemote(path)
+        end)
+    end
+
+    add("StealGames", "Steal a Baddie", "Scripts/Steal a Baddie Project/combined_auto_tp_stealer.lua")
+
+    return controllers
+end

--- a/Scripts/UiLib/loader.lua
+++ b/Scripts/UiLib/loader.lua
@@ -38,6 +38,15 @@ return function()
     )
     print("[loader] sidebar module loaded")
 
+    -- Populate pages with default toggle buttons
+    local toggleLib = loadRemote("Scripts/UiLib/AddToggleGridButton.lua")
+    loadRemote(
+        "Scripts/UiLib/default_buttons.lua",
+        pagesModule,
+        toggleLib,
+        loadRemote
+    )
+
     print("[loader] finished")
 end
 


### PR DESCRIPTION
## Summary
- add `default_buttons.lua` to populate pages with toggleable buttons
- update UI loader to use new module
- document new module in codex structure

## Testing
- `lua` scripts have no automated tests


------
https://chatgpt.com/codex/tasks/task_e_6863017ac1cc83228c9b4bbe2bf568c5