### PR TITLE
Update UI loader with toggles and new default buttons

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -69,9 +69,12 @@ codex_rules_and_structure.txt – this file
 │   │   ↳ Builds the sidebar menu using AddMenuButton.
 │   │   ↳ Connects sidebar buttons to pages.lua page switching.
 │   ├── `default_buttons.lua`
-│   │   ↳ Populates pages with toggleable grid buttons like "Steal a Baddie".
+│   │   ↳ Populates pages with toggleable grid buttons.
+│   │   ↳ Adds "Character Info Watcher" to Research, "Simple ESP" to General,
+│   │     and "Steal a Baddie" to StealGames.
 │   │   ↳ Uses AddToggleGridButton to load modules on demand.
 │   └── `loader.lua`
 │       ↳ Master loader hub for the UI library.
 │       ↳ Dynamically fetches and executes MainUI.lua, pages.lua, and sidebar.lua.
+│       ↳ Sets player info and avatar viewport, and wires menu/X buttons for toggling the UI.
 │       ↳ Prints progress for debugging while doing minimal environment setup.

--- a/Scripts/UiLib/default_buttons.lua
+++ b/Scripts/UiLib/default_buttons.lua
@@ -18,6 +18,8 @@ return function(pagesModule, toggleLib, loadRemote)
         end)
     end
 
+    add("Research", "Character Info Watcher", "Scripts/Research Tools/Character Info Watcher.lua")
+    add("General", "Simple ESP", "Scripts/General Tools/SimpleESP.lua")
     add("StealGames", "Steal a Baddie", "Scripts/Steal a Baddie Project/combined_auto_tp_stealer.lua")
 
     return controllers

--- a/Scripts/UiLib/loader.lua
+++ b/Scripts/UiLib/loader.lua
@@ -19,6 +19,24 @@ return function()
     local ui = loadRemote("Scripts/UiLib/MainUI.lua")
     print("[loader] MainUI loaded")
 
+    -- Personal info setup
+    local Players = game:GetService("Players")
+    ui.Version.Text = "Developer"
+    ui.PlayerName.Text = Players.LocalPlayer.Name
+
+    -- Render the player's avatar in the viewport
+    local viewport = ui.Player
+    viewport:ClearAllChildren()
+    local cam = Instance.new("Camera")
+    cam.Parent = viewport
+    viewport.CurrentCamera = cam
+    local desc = Players:GetHumanoidDescriptionFromUserId(Players.LocalPlayer.UserId)
+    local model = Players:CreateHumanoidModelFromDescription(desc, Enum.HumanoidRigType.R15)
+    local world = Instance.new("WorldModel")
+    world.Parent = viewport
+    model.Parent = world
+    cam.CFrame = CFrame.new(model.Head.Position + Vector3.new(0, 0, 5), model.Head.Position)
+
     -- Utility for cloning sidebar buttons
     local addMenuButton = loadRemote("Scripts/UiLib/AddMenuButton.lua")
 
@@ -46,6 +64,15 @@ return function()
         toggleLib,
         loadRemote
     )
+
+    -- Menu controls
+    ui.MenuButton.MouseButton1Click:Connect(function()
+        ui.Background.Visible = not ui.Background.Visible
+    end)
+
+    ui.X.MouseButton1Click:Connect(function()
+        ui.Background.Visible = false
+    end)
 
     print("[loader] finished")
 end


### PR DESCRIPTION
## Summary
- hook up MenuButton and X button to toggle background frame
- show player name and avatar in personal section
- add Character Info Watcher and Simple ESP buttons
- document updated behaviour in codex rules

## Testing
- `lua` not available, so no automated syntax checks

------
https://chatgpt.com/codex/tasks/task_e_68630528edc48322b51cadc3f5eeb3cf