### PR TITLE
Speed up AIMovement

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -30,7 +30,7 @@ codex_rules_and_structure.txt – this file
 │   │   ↳ Exposes Enable/Disable functions used by UI toggle buttons.
 │   ├── `AIMovement.lua`
 │   │   ↳ Tween-based step movement toward a destination.
-│   │   ↳ Moves every 0.3s until within 2 studs of the goal.
+│   │   ↳ Default 10-stud steps every 0.3s until within 2 studs of the goal.
 │   ├── `AIMovementUI.lua`
 │   │   ↳ Floating UI to set target and start/stop AIMovement.
 │   │   ↳ Displays brief debug messages while moving.

--- a/Scripts/General Tools/AIMovement.lua
+++ b/Scripts/General Tools/AIMovement.lua
@@ -21,7 +21,7 @@ local function stepTowards(destination, stepDistance)
     if currentTween then
         currentTween:Cancel()
     end
-    currentTween = TweenService:Create(root, TweenInfo.new(0.28, Enum.EasingStyle.Linear), {CFrame = CFrame.new(nextPos)})
+    currentTween = TweenService:Create(root, TweenInfo.new(0.3, Enum.EasingStyle.Linear), {CFrame = CFrame.new(nextPos)})
     currentTween:Play()
     currentTween.Completed:Wait()
     return distance - travel
@@ -30,14 +30,13 @@ end
 function module.Start(destination, stepDistance)
     if moving then return end
     moving = true
-    local step = stepDistance or 4
+    local step = stepDistance or 10
     moveThread = task.spawn(function()
         while moving do
-            local remaining = stepTowards(destination, math.clamp(step, 2, 5))
+            local remaining = stepTowards(destination, math.clamp(step, 2, 10))
             if remaining <= 2 then
                 break
             end
-            task.wait(0.3)
         end
         moving = false
     end)


### PR DESCRIPTION
## Summary
- increase AIMovement tween duration to 0.3s and default step to 10 studs
- document new default step speed in codex rules

## Testing
- `luac -p 'Scripts/General Tools/AIMovement.lua'` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686316ab9584832294c0d5521e7e841f