### PR TITLE
Switch AI movement to BodyVelocity

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -29,8 +29,8 @@ codex_rules_and_structure.txt – this file
 │   │   ↳ Provides basic Highlight-based ESP for other players.
 │   │   ↳ Exposes Enable/Disable functions used by UI toggle buttons.
 │   ├── `AIMovement.lua`
-│   │   ↳ Tween-based step movement toward a destination.
-│   │   ↳ Default 10-stud steps every 0.3s until within 2 studs of the goal.
+│   │   ↳ BodyVelocity-based dashing toward a destination.
+│   │   ↳ Creates short 0.3s bursts at ~60 studs/s until within 2 studs.
 │   ├── `AIMovementUI.lua`
 │   │   ↳ Floating UI to set target and start/stop AIMovement.
 │   │   ↳ Displays brief debug messages while moving.

--- a/Scripts/General Tools/AIMovement.lua
+++ b/Scripts/General Tools/AIMovement.lua
@@ -1,9 +1,8 @@
 local module = {}
 local Players = game:GetService("Players")
-local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
 
 local moving = false
-local currentTween
 local moveThread
 
 local function getRoot()
@@ -11,40 +10,42 @@ local function getRoot()
     return char:WaitForChild("HumanoidRootPart")
 end
 
-local function stepTowards(destination, stepDistance)
-    local root = getRoot()
-    local offset = destination - root.Position
-    local distance = offset.Magnitude
-    if distance <= 0 then return distance end
-    local travel = math.min(stepDistance, distance)
-    local nextPos = root.Position + offset.Unit * travel
-    if currentTween then
-        currentTween:Cancel()
-    end
-    currentTween = TweenService:Create(root, TweenInfo.new(0.3, Enum.EasingStyle.Linear), {CFrame = CFrame.new(nextPos)})
-    currentTween:Play()
-    currentTween.Completed:Wait()
-    return distance - travel
-end
 
-function module.Start(destination, stepDistance)
+function module.Start(destination, speed)
     if moving then return end
     moving = true
-    local step = stepDistance or 10
+    local stepDuration = 0.3
+    local dashSpeed = speed or 60
+    local humanoid = Players.LocalPlayer.Character and Players.LocalPlayer.Character:FindFirstChildOfClass("Humanoid")
+    if humanoid then
+        humanoid.AutoRotate = false
+    end
     moveThread = task.spawn(function()
         while moving do
-            local remaining = stepTowards(destination, math.clamp(step, 2, 10))
-            if remaining <= 2 then
+            local root = getRoot()
+            local offset = destination - root.Position
+            local distance = offset.Magnitude
+            if distance <= 2 then
                 break
             end
+
+            local bv = Instance.new("BodyVelocity")
+            bv.Velocity = offset.Unit * dashSpeed
+            bv.MaxForce = Vector3.new(1e5, 0, 1e5)
+            bv.Parent = root
+            Debris:AddItem(bv, stepDuration)
+
+            task.wait(stepDuration)
         end
         moving = false
+        if humanoid then
+            humanoid.AutoRotate = true
+        end
     end)
 end
 
 function module.Stop()
     moving = false
-    if currentTween then currentTween:Cancel() end
     if moveThread then task.cancel(moveThread) end
 end
 


### PR DESCRIPTION
## Summary
- rewrite AIMovement module to use BodyVelocity bursts instead of TweenService
- document new dash behaviour in codex_rules_and_structure

## Testing
- `lua -v` *(fails: command not found)*
- `lua5.1 -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631b24e76083229321ffe9f7560e3a