### PR TITLE
Add toggleable Speed module

### DIFF
--- a/Docs/codex_rules_and_structure.txt
+++ b/Docs/codex_rules_and_structure.txt
@@ -41,6 +41,9 @@ codex_rules_and_structure.txt – this file
 │   ├── `Flight.lua`
 │   │   ↳ BodyVelocity-based flight with WASD controls and toggle support.
 │   │   ↳ Uses RenderStep loop similar to provided fly script.
+│   ├── `Speed.lua`
+│   │   ↳ Simple toggle to increase WalkSpeed to 50 studs/s.
+│   │   ↳ Restores original speed when disabled.
 
 ├── 📁 Research Tools
 │   └── `Character Info Watcher.lua`

--- a/Scripts/General Tools/Speed.lua
+++ b/Scripts/General Tools/Speed.lua
@@ -1,0 +1,33 @@
+local module = {}
+
+local Players = game:GetService("Players")
+
+local enabled = false
+local originalSpeed
+local speed = 50
+
+local function getHumanoid()
+    local char = Players.LocalPlayer.Character or Players.LocalPlayer.CharacterAdded:Wait()
+    return char:FindFirstChildOfClass("Humanoid")
+end
+
+function module.Enable()
+    if enabled then return end
+    enabled = true
+    local hum = getHumanoid()
+    if hum then
+        originalSpeed = hum.WalkSpeed
+        hum.WalkSpeed = speed
+    end
+end
+
+function module.Disable()
+    if not enabled then return end
+    enabled = false
+    local hum = Players.LocalPlayer.Character and Players.LocalPlayer.Character:FindFirstChildOfClass("Humanoid")
+    if hum then
+        hum.WalkSpeed = originalSpeed or 16
+    end
+end
+
+return module

--- a/Scripts/UiLib/default_buttons.lua
+++ b/Scripts/UiLib/default_buttons.lua
@@ -22,6 +22,7 @@ return function(pagesModule, toggleLib, loadRemote)
     add("General", "Simple ESP", "Scripts/General Tools/SimpleESP.lua")
     add("General", "Noclip", "Scripts/General Tools/Noclip.lua")
     add("General", "Flight", "Scripts/General Tools/Flight.lua")
+    add("General", "Speed", "Scripts/General Tools/Speed.lua")
     add("StealGames", "Steal a Baddie", "Scripts/Steal a Baddie Project/combined_auto_tp_stealer.lua")
 
     do


### PR DESCRIPTION
## Summary
- add new `Speed.lua` script that boosts WalkSpeed and restores the normal speed when toggled off
- register new Speed button in `default_buttons.lua`
- document the new script in `codex_rules_and_structure.txt`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6863764be1308322ad709a128620d383